### PR TITLE
bugfix/2024_11_24

### DIFF
--- a/functions/theme-functions.php
+++ b/functions/theme-functions.php
@@ -20,11 +20,25 @@ class Home_Stylized_Walker extends Walker_Nav_Menu {
     $id = $item->ID;
     $title = $item->title;
     $permalink = $item->url;
-    $pageObj = get_page_by_title($title);
-    if ( get_field('page_color', $pageObj->ID) ) :
-      $color = get_field('page_color', $pageObj->ID);
-    else : 
-      $color = '#484848';
+    $pageQuery = new WP_Query(
+      array(
+        'post_type'  => 'page',
+        'title'      => $title,
+      )
+    );
+
+    if ( ! empty( $pageQuery->post ) ) {
+      $pageObj = $pageQuery->post;
+    } else {
+      $pageObj = null;
+    }
+
+    if ( $pageObj ) :
+      if ( get_field('page_color', $pageObj->ID) ) :
+        $color = get_field('page_color', $pageObj->ID);
+      else : 
+        $color = '#484848';
+      endif;
     endif;
 
     $output .= '
@@ -50,11 +64,25 @@ class Menu_Stylized_Walker extends Walker_Nav_Menu {
     $id = $item->ID;
     $title = $item->title;
     $permalink = $item->url;
-    $pageObj = get_page_by_title($title);
-    if ( get_field('page_color', $pageObj->ID) ) :
-      $color = get_field('page_color', $pageObj->ID);
-    else : 
-      $color = '#484848';
+    $pageQuery = new WP_Query(
+      array(
+        'post_type'  => 'page',
+        'title'      => $title,
+      )
+    );
+
+    if ( ! empty( $pageQuery->post ) ) {
+      $pageObj = $pageQuery->post;
+    } else {
+      $pageObj = null;
+    }
+
+    if ( $pageObj ) :
+      if ( get_field('page_color', $pageObj->ID) ) :
+        $color = get_field('page_color', $pageObj->ID);
+      else : 
+        $color = '#484848';
+      endif;
     endif;
 
     $output .= '

--- a/header.php
+++ b/header.php
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <!--[if IE 7]>
-<html class="ie ie7" <? language_attributes(); ?>>
+<html class="ie ie7" <?php language_attributes(); ?>>
 <![endif]-->
 <!--[if IE 8]>
-<html class="ie ie8" <? language_attributes(); ?>>
+<html class="ie ie8" <?php language_attributes(); ?>>
 <![endif]-->
 <!--[if !(IE 7) & !(IE 8)]><!-->
 <html 
-<? language_attributes(); ?>
+<?php language_attributes(); ?>
 <?php if ( is_page_template('templates/portfolio-sidebar.php') ) : ?>
 class="has-sidebar"
 <?php endif; ?>


### PR DESCRIPTION
1. Uses <?php opening tag instead of <? shorthand
2. Removes [deprecated get_page_by_title](https://make.wordpress.org/core/2023/03/06/get_page_by_title-deprecated/) in favor of WP_Query